### PR TITLE
Fix write permissions.

### DIFF
--- a/src/ios/Zip/TLKZipArchive.m
+++ b/src/ios/Zip/TLKZipArchive.m
@@ -11,6 +11,7 @@
 #include "zip.h"
 #import "zlib.h"
 #import "zconf.h"
+#include <errno.h>
 
 #include <sys/stat.h>
 
@@ -237,7 +238,16 @@
 			}
 
 			if (!fileIsSymbolicLink) {
+                if ([NSFileManager.defaultManager fileExistsAtPath:fullPath]) {
+                    [NSFileManager.defaultManager removeItemAtPath:fullPath error:nil];
+                }
+                
 	            FILE *fp = fopen((const char*)[fullPath UTF8String], "wb");
+                
+                if(!fp){
+                    NSLog(@"Error%s", strerror(errno));
+                }
+                
 	            while (fp) {
 	                int readBytes = unzReadCurrentFile(zip, buffer, 4096);
 


### PR DESCRIPTION
When extracting files from the zip TLKZipArchiver use c++ function [fopen](http://www.cplusplus.com/reference/cstdio/fopen/) to write files as binary with mode "wb". This mode specifier "w" means "Create an empty file for output operations. If a file with the same name already exists, its contents are discarded and the file is treated as a new empty file" and the  "b" mode is for opening a file as binary. However, if we don't have write permissions the override operations fell silently.

ping @galexandrov and @e2l3n 
